### PR TITLE
Nautilus compatibility for upmap-remapped.py

### DIFF
--- a/scripts/upmap-remapped.py
+++ b/scripts/upmap-remapped.py
@@ -88,6 +88,9 @@ def rm_upmap_pg_items(pgid):
 try:
   remapped_json = commands.getoutput('ceph pg ls remapped -f json')
   remapped = json.loads(remapped_json)
+  # For Nautilus+ the the pgs are listed within pg_stats
+  if 'pg_stats' in remapped:
+    remapped = remapped['pg_stats']
 except ValueError:
   eprint('Error loading remapped pgs')
   sys.exit(1)


### PR DESCRIPTION
I have only been able to test this change against a "mimic" cluster.  
We still need to test it with a Nautilus cluster that has remapped PGs.

My python skill are pretty rudimentary - if there is a cleaner/better way to implement this, please feel free to do so.