### PR TITLE
update increase_pgs.py to eliminate race condition

### DIFF
--- a/scripts/increase_pgs.py
+++ b/scripts/increase_pgs.py
@@ -82,11 +82,12 @@ while pool_pgs < max_pgs:
     sys.stdout.flush()
     set_pool_pgs( pool, new_pgs )
 
+  time.sleep( 30 )
+
   pool_pgs = get_pool_pgs( pool )
   # if we've hit the target quit
   if pool_pgs == max_pgs:
     print(str(datetime.datetime.now()) + "Pool " + pool + " set to " + str(pool_pgs) + ".  Update complete")
     exit(0)
 
-  time.sleep( 30 )
 


### PR DESCRIPTION
We change the number of PGs, then immediately read the number of PGs.  Sometimes the change has not propagated, causing us to read the "old" value of PGs. To  eliminate this race condition, I'm moving the sleep up before reading the number of PGs.